### PR TITLE
Добавление data objects

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'io.fabric'
 apply plugin: 'com.google.firebase.firebase-perf'
+apply plugin: 'de.mannodermaus.android-junit5'
 
 android {
     compileSdkVersion 27
@@ -19,8 +20,14 @@ android {
         }
     }
     compileOptions {
+        incremental false /* incremental compilation breaks unit tests */
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+    testOptions.junitPlatform {
+        jupiterVersion '5.2.0'
+        platformVersion '1.2.0'
+        vintageVersion '5.2.0'
     }
 }
 
@@ -54,6 +61,9 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     implementation "net.sourceforge.htmlcleaner:htmlcleaner:${htmlcleanerVersion}"
     implementation "com.squareup.picasso:picasso:${picassoVersion}"
+    // tests
+    testImplementation junit5.unitTests()
+    testImplementation "org.json:json:20080701"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/com/bukhmastov/cdoitmo/activity/LoginActivity.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/activity/LoginActivity.java
@@ -145,7 +145,7 @@ public class LoginActivity extends ConnectedActivity {
                 }
                 case SIGNAL_CHANGE_ACCOUNT: {
                     if (UserCredentials.hasCurrentLogin(storage)) {
-                        Account.logoutTemporarily(activity, this::show);
+                        Account.clearAuthorization(/* permanently? */ false, activity, this::show);
                     } else {
                         show();
                     }
@@ -168,7 +168,7 @@ public class LoginActivity extends ConnectedActivity {
                 case SIGNAL_CREDENTIALS_REQUIRED: {
                     if (UserCredentials.hasCurrentLogin(storage)) {
                         UserCredentials.clearCookies(storage);
-                        Account.logoutTemporarily(activity, () -> {
+                        Account.clearAuthorization(/* permanently? */ false, activity, () -> {
                             BottomBar.snackBar(activity, activity.getString(R.string.required_login_password));
                             show();
                         });
@@ -180,7 +180,7 @@ public class LoginActivity extends ConnectedActivity {
                     if (UserCredentials.hasCurrentLogin(storage)) {
                         UserCredentials.clearCookies(storage);
                         UserCredentials.clearPassword(storage);
-                        Account.logoutTemporarily(activity, () -> {
+                        Account.clearAuthorization(/* permanently? */ false, activity, () -> {
                             BottomBar.snackBar(activity, activity.getString(R.string.invalid_login_password));
                             show();
                         });

--- a/app/src/main/java/com/bukhmastov/cdoitmo/activity/LoginActivity.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/activity/LoginActivity.java
@@ -7,7 +7,6 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.PopupMenu;
 import android.support.v7.widget.Toolbar;
-import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -18,6 +17,10 @@ import android.widget.TextView;
 
 import com.bukhmastov.cdoitmo.App;
 import com.bukhmastov.cdoitmo.R;
+import com.bukhmastov.cdoitmo.data.AccountList;
+import com.bukhmastov.cdoitmo.data.StorageProxy;
+import com.bukhmastov.cdoitmo.data.User;
+import com.bukhmastov.cdoitmo.data.UserCredentials;
 import com.bukhmastov.cdoitmo.firebase.FirebaseAnalyticsProvider;
 import com.bukhmastov.cdoitmo.firebase.FirebaseConfigProvider;
 import com.bukhmastov.cdoitmo.fragment.AboutFragment;
@@ -31,9 +34,6 @@ import com.bukhmastov.cdoitmo.util.Storage;
 import com.bukhmastov.cdoitmo.util.Theme;
 import com.bukhmastov.cdoitmo.util.Thread;
 import com.bukhmastov.cdoitmo.view.Message;
-
-import org.json.JSONArray;
-import org.json.JSONException;
 
 public class LoginActivity extends ConnectedActivity {
 
@@ -50,6 +50,8 @@ public class LoginActivity extends ConnectedActivity {
 
     private Client.Request requestHandle = null;
     public static boolean auto_logout = false;
+
+    private StorageProxy storage = new Storage.Proxy(activity);
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -142,8 +144,7 @@ public class LoginActivity extends ConnectedActivity {
                     break;
                 }
                 case SIGNAL_CHANGE_ACCOUNT: {
-                    String current_login = Storage.file.general.perm.get(activity, "users#current_login");
-                    if (!current_login.isEmpty()) {
+                    if (UserCredentials.hasCurrentLogin(storage)) {
                         Account.logoutTemporarily(activity, this::show);
                     } else {
                         show();
@@ -151,26 +152,22 @@ public class LoginActivity extends ConnectedActivity {
                     break;
                 }
                 case SIGNAL_DO_CLEAN_AUTH: {
-                    String current_login = Storage.file.general.perm.get(activity, "users#current_login");
-                    if (!current_login.isEmpty()) {
-                        Storage.file.perm.delete(activity, "user#deifmo#cookies");
-                    }
+                    UserCredentials.clearCookies(storage);
                     show();
                     break;
                 }
                 case SIGNAL_LOGOUT: {
-                    String current_login = Storage.file.general.perm.get(activity, "users#current_login");
-                    if (!current_login.isEmpty()) {
-                        logout(current_login);
+                    String currentLogin = UserCredentials.getCurrentLogin(storage);
+                    if (!currentLogin.isEmpty()) {
+                        logout(currentLogin);
                     } else {
                         show();
                     }
                     break;
                 }
                 case SIGNAL_CREDENTIALS_REQUIRED: {
-                    String current_login = Storage.file.general.perm.get(activity, "users#current_login");
-                    if (!current_login.isEmpty()) {
-                        Storage.file.perm.delete(activity, "user#deifmo#cookies");
+                    if (UserCredentials.hasCurrentLogin(storage)) {
+                        UserCredentials.clearCookies(storage);
                         Account.logoutTemporarily(activity, () -> {
                             BottomBar.snackBar(activity, activity.getString(R.string.required_login_password));
                             show();
@@ -180,10 +177,9 @@ public class LoginActivity extends ConnectedActivity {
                     break;
                 }
                 case SIGNAL_CREDENTIALS_FAILED: {
-                    String current_login = Storage.file.general.perm.get(activity, "users#current_login");
-                    if (!current_login.isEmpty()) {
-                        Storage.file.perm.delete(activity, "user#deifmo#cookies");
-                        Storage.file.perm.delete(activity, "user#deifmo#password");
+                    if (UserCredentials.hasCurrentLogin(storage)) {
+                        UserCredentials.clearCookies(storage);
+                        UserCredentials.clearPassword(storage);
                         Account.logoutTemporarily(activity, () -> {
                             BottomBar.snackBar(activity, activity.getString(R.string.invalid_login_password));
                             show();
@@ -205,16 +201,10 @@ public class LoginActivity extends ConnectedActivity {
             try {
                 Log.v(TAG, "show");
                 FirebaseAnalyticsProvider.logEvent(activity, FirebaseAnalyticsProvider.Event.LOGIN_REQUIRED);
-                String current_login = Storage.file.general.perm.get(activity, "users#current_login");
-                String cLogin = "", cPassword = "", cRole = "";
-                if (!current_login.isEmpty()) {
-                    cLogin = Storage.file.perm.get(activity, "user#deifmo#login");
-                    cPassword = Storage.file.perm.get(activity, "user#deifmo#password");
-                    cRole = Storage.file.perm.get(activity, "user#role");
-                }
-                if (!cLogin.isEmpty() && !cPassword.isEmpty()) {
+                UserCredentials credentials = UserCredentials.load(new Storage.Proxy(activity));
+                if (credentials != null) {
                     // already logged in
-                    login(cLogin, cPassword, cRole, false);
+                    login(credentials, false);
                 } else {
                     // show login UI
                     final LinearLayout login_tiles_container = new LinearLayout(activity);
@@ -230,7 +220,7 @@ public class LoginActivity extends ConnectedActivity {
                         String password = "";
                         if (input_login != null) login = input_login.getText().toString();
                         if (input_password != null) password = input_password.getText().toString();
-                        login(login, password, "student", true);
+                        login(new UserCredentials(login, password, "student"), true);
                     });
                     new_user_tile.findViewById(R.id.help).setOnClickListener(view -> {
                         FirebaseAnalyticsProvider.logBasicEvent(getBaseContext(), "Help with login clicked");
@@ -249,147 +239,121 @@ public class LoginActivity extends ConnectedActivity {
                     });
                     login_tiles_container.addView(new_user_tile);
                     // show UI: list of existing accounts
-                    final JSONArray accounts = Account.List.get(activity);
-                    for (int i = 0; i < accounts.length(); i++) {
-                        try {
-                            final String acLogin = accounts.getString(i);
-                            Log.v(TAG, "show | account in accounts | ", acLogin);
-                            Storage.file.general.perm.put(activity, "users#current_login", acLogin);
-                            final String login = Storage.file.perm.get(activity, "user#deifmo#login");
-                            final String password = Storage.file.perm.get(activity, "user#deifmo#password");
-                            final String role = Storage.file.perm.get(activity, "user#role");
-                            final String name = Storage.file.perm.get(activity, "user#name").trim();
-                            Storage.file.general.perm.delete(activity, "users#current_login");
-                            final ViewGroup user_tile = (ViewGroup) inflate(R.layout.layout_login_user_tile);
-                            View nameView = user_tile.findViewById(R.id.name);
-                            View descView = user_tile.findViewById(R.id.desc);
-                            String desc = "";
-                            if (!login.isEmpty()) {
-                                desc += login;
-                            }
-                            switch (role) {
-                                case "student": {
-                                    desc += desc.isEmpty() ? activity.getString(R.string.student) : " (" + activity.getString(R.string.student) + ")";
-                                    break;
-                                }
-                                default: {
-                                    desc += desc.isEmpty() ? role : " (" + role + ")";
-                                    break;
-                                }
-                            }
-                            if (!name.isEmpty()) {
-                                if (nameView != null) {
-                                    ((TextView) nameView).setText(name);
-                                }
-                                if (descView != null) {
-                                    ((TextView) descView).setText(desc);
-                                }
-                            } else {
-                                if (nameView != null) {
-                                    ((TextView) nameView).setText(desc);
-                                }
-                                if (descView != null) {
-                                    Static.removeView(descView);
-                                }
-                            }
-                            user_tile.findViewById(R.id.auth).setOnClickListener(v -> {
-                                Log.v(TAG, "user_tile login clicked");
-                                login(login, password, role, false);
-                            });
-                            user_tile.findViewById(R.id.expand_auth_menu).setOnClickListener(view -> {
-                                Log.v(TAG, "user_tile expand_auth_menu clicked");
-                                final PopupMenu popup = new PopupMenu(activity, view);
-                                final Menu menu = popup.getMenu();
-                                popup.getMenuInflater().inflate(R.menu.auth_expanded_menu, menu);
-                                popup.setOnMenuItemClickListener(item -> {
-                                    Log.v(TAG, "auth_expanded_menu | popup.MenuItem clicked | ", item.getTitle().toString());
-                                    switch (item.getItemId()) {
-                                        case R.id.offline: {
-                                            Storage.file.general.perm.put(activity, "users#current_login", login);
-                                            route(SIGNAL_GO_OFFLINE);
-                                            break;
-                                        }
-                                        case R.id.clean_auth: {
-                                            Storage.file.general.perm.put(activity, "users#current_login", login);
-                                            route(SIGNAL_DO_CLEAN_AUTH);
-                                            break;
-                                        }
-                                        case R.id.logout: {
-                                            Account.logoutConfirmation(activity, () -> logout(login));
-                                            break;
-                                        }
-                                        case R.id.change_password: {
-                                            Thread.runOnUI(() -> {
-                                                try {
-                                                    final View layout = inflate(R.layout.preference_dialog_input);
-                                                    final EditText editText = layout.findViewById(R.id.edittext);
-                                                    final TextView message = layout.findViewById(R.id.message);
-                                                    editText.setHint(R.string.new_password);
-                                                    message.setText(activity.getString(R.string.change_password_message).replace("%login%", login));
-                                                    new AlertDialog.Builder(activity)
-                                                            .setTitle(R.string.change_password_title)
-                                                            .setView(layout)
-                                                            .setPositiveButton(R.string.accept, (dialog, which) -> {
-                                                                try {
-                                                                    final String value = editText.getText().toString().trim();
-                                                                    if (!value.isEmpty()) {
-                                                                        Thread.run(() -> {
-                                                                            Storage.file.general.perm.put(activity, "users#current_login", acLogin);
-                                                                            Storage.file.perm.put(activity, "user#deifmo#password", value);
-                                                                            Storage.file.general.perm.delete(activity, "users#current_login");
-                                                                            BottomBar.snackBar(activity, activity.getString(R.string.password_changed));
-                                                                        });
-                                                                    }
-                                                                } catch (Exception e) {
-                                                                    Log.exception(e);
-                                                                }
-                                                            })
-                                                            .setNegativeButton(R.string.cancel, null)
-                                                            .create().show();
-                                                } catch (Exception e) {
-                                                    Log.exception(e);
-                                                }
-                                            });
-                                            break;
-                                        }
-                                    }
-                                    return false;
-                                });
-                                popup.show();
-                            });
-                            login_tiles_container.addView(user_tile);
-                        } catch (JSONException e) {
-                            Log.exception(e);
+                    for (AccountList.AccountEntry account : new AccountList(storage)) {
+                        if (account == null) continue;
+                        Log.v(TAG, "show | account in accounts | ", account.creds.getLogin());
+                        final ViewGroup user_tile = (ViewGroup) inflate(R.layout.layout_login_user_tile);
+                        View nameView = user_tile.findViewById(R.id.name);
+                        View descView = user_tile.findViewById(R.id.desc);
+                        String desc = "";
+                        if (!account.creds.getLogin().isEmpty()) {
+                            desc += account.creds.getLogin();
                         }
+                        switch (account.creds.getRole()) {
+                            case "student": {
+                                desc += desc.isEmpty() ? activity.getString(R.string.student) : " (" + activity.getString(R.string.student) + ")";
+                                break;
+                            }
+                            default: {
+                                desc += desc.isEmpty() ? account.creds.getRole() : " (" + account.creds.getRole() + ")";
+                                break;
+                            }
+                        }
+                        if (!account.name.isEmpty()) {
+                            if (nameView != null) {
+                                ((TextView) nameView).setText(account.name);
+                            }
+                            if (descView != null) {
+                                ((TextView) descView).setText(desc);
+                            }
+                        } else {
+                            if (nameView != null) {
+                                ((TextView) nameView).setText(desc);
+                            }
+                            if (descView != null) {
+                                Static.removeView(descView);
+                            }
+                        }
+                        user_tile.findViewById(R.id.auth).setOnClickListener(v -> {
+                            Log.v(TAG, "user_tile login clicked");
+                            login(account.creds, false);
+                        });
+                        user_tile.findViewById(R.id.expand_auth_menu).setOnClickListener(view -> {
+                            Log.v(TAG, "user_tile expand_auth_menu clicked");
+                            final PopupMenu popup = new PopupMenu(activity, view);
+                            final Menu menu = popup.getMenu();
+                            popup.getMenuInflater().inflate(R.menu.auth_expanded_menu, menu);
+                            popup.setOnMenuItemClickListener(item -> {
+                                Log.v(TAG, "auth_expanded_menu | popup.MenuItem clicked | ", item.getTitle().toString());
+                                switch (item.getItemId()) {
+                                    case R.id.offline: {
+                                        UserCredentials.setCurrentLogin(storage, account.creds.getLogin());
+                                        route(SIGNAL_GO_OFFLINE);
+                                        break;
+                                    }
+                                    case R.id.clean_auth: {
+                                        UserCredentials.setCurrentLogin(storage, account.creds.getLogin());
+                                        route(SIGNAL_DO_CLEAN_AUTH);
+                                        break;
+                                    }
+                                    case R.id.logout: {
+                                        Account.logoutConfirmation(activity, () -> logout(account.creds.getLogin()));
+                                        break;
+                                    }
+                                    case R.id.change_password: {
+                                        Thread.runOnUI(() -> {
+                                            try {
+                                                final View layout = inflate(R.layout.preference_dialog_input);
+                                                final EditText editText = layout.findViewById(R.id.edittext);
+                                                final TextView message = layout.findViewById(R.id.message);
+                                                editText.setHint(R.string.new_password);
+                                                message.setText(activity.getString(R.string.change_password_message).replace("%login%", account.creds.getLogin()));
+                                                new AlertDialog.Builder(activity)
+                                                        .setTitle(R.string.change_password_title)
+                                                        .setView(layout)
+                                                        .setPositiveButton(R.string.accept, (dialog, which) -> {
+                                                            try {
+                                                                final String value = editText.getText().toString().trim();
+                                                                if (!value.isEmpty()) {
+                                                                    Thread.run(() -> {
+                                                                        UserCredentials.changePasswordByLogin(storage, account.creds.getLogin(), value);
+                                                                        BottomBar.snackBar(activity, activity.getString(R.string.password_changed));
+                                                                    });
+                                                                }
+                                                            } catch (Exception e) {
+                                                                Log.exception(e);
+                                                            }
+                                                        })
+                                                        .setNegativeButton(R.string.cancel, null)
+                                                        .create().show();
+                                            } catch (Exception e) {
+                                                Log.exception(e);
+                                            }
+                                        });
+                                        break;
+                                    }
+                                }
+                                return false;
+                            });
+                            popup.show();
+                        });
+                        login_tiles_container.addView(user_tile);
                     }
                     // show UI: anonymous login
                     final ViewGroup anonymous_user_tile = (ViewGroup) inflate(R.layout.layout_login_anonymous_user_tile);
                     final EditText input_group = anonymous_user_tile.findViewById(R.id.input_group);
                     anonymous_user_tile.findViewById(R.id.login).setOnClickListener(view -> {
                         Log.v(TAG, "anonymous_user_tile login clicked");
+
                         String group = "";
                         if (input_group != null) {
                             group = com.bukhmastov.cdoitmo.util.TextUtils.prettifyGroupNumber(input_group.getText().toString());
                         }
-                        String[] groups = group.split(",\\s|\\s|,");
-                        Storage.file.general.perm.put(activity, "users#current_login", Account.USER_UNAUTHORIZED);
-                        String g = Storage.file.perm.get(activity, "user#group");
-                        boolean gFound = false;
-                        for (String g1 : groups) {
-                            if (g1.equals(g)) {
-                                gFound = true;
-                                break;
-                            }
-                        }
-                        if (!gFound) {
-                            g = groups.length > 0 ? groups[0] : "";
-                        }
-                        Storage.file.perm.put(activity, "user#name", activity.getString(R.string.anonymous));
-                        Storage.file.perm.put(activity, "user#group", g);
-                        Storage.file.perm.put(activity, "user#groups", TextUtils.join(", ", groups));
-                        Storage.file.perm.put(activity, "user#avatar", "");
-                        Storage.file.general.perm.delete(activity, "users#current_login");
-                        login(Account.USER_UNAUTHORIZED, Account.USER_UNAUTHORIZED, "anonymous", false);
+
+                        UserCredentials.setCurrentLogin(storage, UserCredentials.LOGIN_UNAUTHORIZED);
+                        new User(activity.getString(R.string.anonymous), "", group, null).store(storage);
+                        UserCredentials.resetCurrentLogin(storage);
+                        login(UserCredentials.UNAUTHORIZED, false);
                     });
                     anonymous_user_tile.findViewById(R.id.expand_auth_menu).setOnClickListener(view -> {
                         Log.v(TAG, "anonymous_user_tile expand_auth_menu clicked");
@@ -398,12 +362,9 @@ public class LoginActivity extends ConnectedActivity {
                         popup.getMenuInflater().inflate(R.menu.auth_anonymous_expanded_menu, menu);
                         popup.setOnMenuItemClickListener(item -> {
                             Log.v(TAG, "auth_expanded_menu | popup.MenuItem clicked | ", item.getTitle().toString());
-                            switch (item.getItemId()) {
-                                case R.id.offline: {
-                                    Storage.file.general.perm.put(activity, "users#current_login", Account.USER_UNAUTHORIZED);
-                                    route(SIGNAL_GO_OFFLINE);
-                                    break;
-                                }
+                            if (item.getItemId() == R.id.offline) {
+                                UserCredentials.setCurrentLogin(storage, UserCredentials.LOGIN_UNAUTHORIZED);
+                                route(SIGNAL_GO_OFFLINE);
                             }
                             return false;
                         });
@@ -424,7 +385,7 @@ public class LoginActivity extends ConnectedActivity {
                                 .create().show();
                     });
                     login_tiles_container.addView(anonymous_user_tile);
-                    Storage.file.general.perm.put(activity, "users#current_login", Account.USER_UNAUTHORIZED);
+                    Storage.file.general.perm.put(activity, "users#current_login", UserCredentials.LOGIN_UNAUTHORIZED);
                     input_group.setText(Storage.file.perm.get(activity, "user#groups", ""));
                     Storage.file.general.perm.delete(activity, "users#current_login");
                     // draw UI
@@ -443,10 +404,10 @@ public class LoginActivity extends ConnectedActivity {
             }
         });
     }
-    private void login(final String login, final String password, final String role, final boolean isNewUser) {
-        Log.v(TAG, "login | login=", login, " | role=", role, " | isNewUser=", isNewUser);
+    private void login(final UserCredentials creds, final boolean isNewUser) {
+        Log.v(TAG, "login | login=", creds.getLogin(), " | role=", creds.getRole(), " | isNewUser=", isNewUser);
         Static.lockOrientation(activity, true);
-        Account.login(activity, login, password, role, isNewUser, new Account.LoginHandler() {
+        Account.login(activity, creds, isNewUser, new Account.LoginHandler() {
             @Override
             public void onSuccess() {
                 Log.v(TAG, "login | onSuccess");
@@ -463,7 +424,7 @@ public class LoginActivity extends ConnectedActivity {
             public void onInterrupted() {
                 Log.v(TAG, "login | onInterrupted");
                 FirebaseAnalyticsProvider.logBasicEvent(activity, "login interrupted");
-                Storage.file.general.perm.put(activity, "users#current_login", login);
+                UserCredentials.setCurrentLogin(storage, creds.getLogin());
                 route(SIGNAL_GO_OFFLINE);
                 Static.lockOrientation(activity, false);
             }

--- a/app/src/main/java/com/bukhmastov/cdoitmo/data/AccountList.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/data/AccountList.java
@@ -1,0 +1,117 @@
+package com.bukhmastov.cdoitmo.data;
+
+import android.support.annotation.NonNull;
+
+import com.bukhmastov.cdoitmo.util.Log;
+import com.bukhmastov.cdoitmo.util.TextUtils;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.util.Iterator;
+
+import static com.bukhmastov.cdoitmo.util.Storage.StorageType.GLOBAL;
+
+public class AccountList implements Iterable<AccountList.AccountEntry> {
+    private final StorageProxy storage;
+    private int size = -1;
+
+    public AccountList(StorageProxy storage) {
+        this.storage = storage;
+    }
+
+    public int length() {
+        if (size >= 0) return size;
+        return get().length();
+    }
+
+    public JSONArray get() {
+        try {
+            return TextUtils.string2jsonArray(storage.get(GLOBAL, "users#list"));
+        } catch (Exception e) {
+            Log.exception(e);
+            return new JSONArray();
+        }
+    }
+
+    public boolean add(@NonNull String login) {
+        if (login.equals(UserCredentials.LOGIN_UNAUTHORIZED)) return false;
+        try {
+            boolean isNewAuthorization = true;
+            // save login on top of the list of authorized users
+            JSONArray list = get();
+            JSONArray accounts = new JSONArray();
+            accounts.put(login);
+            for (int i = 0; i < list.length(); i++) {
+                String entry = list.getString(i);
+                if (entry.equals(login)) {
+                    isNewAuthorization = false;
+                } else {
+                    accounts.put(entry);
+                }
+            }
+            storage.put(GLOBAL, "users#list", accounts.toString());
+            size = accounts.length();
+            return isNewAuthorization;
+        } catch (Exception e) {
+            Log.exception(e);
+        }
+        return false;
+    }
+
+    public void remove(@NonNull final String login) {
+        if (login.equals(UserCredentials.LOGIN_UNAUTHORIZED)) return;
+        try {
+            JSONArray accounts = get();
+            for (int i = 0; i < accounts.length(); i++) {
+                if (accounts.getString(i).equals(login)) {
+                    accounts.remove(i);
+                    break;
+                }
+            }
+            storage.put(GLOBAL, "users#list", accounts.toString());
+            size = accounts.length();
+        } catch (Exception e) {
+            Log.exception(e);
+        }
+    }
+
+    public static class AccountEntry {
+        public final UserCredentials creds;
+        public final String name;
+
+        AccountEntry(UserCredentials creds, String name) {
+            this.creds = creds;
+            this.name = name;
+        }
+    }
+
+    @NonNull
+    @Override
+    public Iterator<AccountEntry> iterator() {
+        return new Iterator<AccountEntry>() {
+            private final JSONArray accounts = get();
+            private int index = 0;
+
+            @Override
+            public boolean hasNext() {
+                return index < accounts.length();
+            }
+
+            @Override
+            public AccountEntry next() {
+                try {
+                    final String login = accounts.getString(index++);
+                    UserCredentials.setCurrentLogin(storage, login);
+                    UserCredentials creds = UserCredentials.load(storage);
+                    String name = User.getName(storage);
+                    UserCredentials.resetCurrentLogin(storage);
+                    return new AccountEntry(creds, name);
+                }
+                catch (JSONException e) {
+                    return null;
+                }
+            }
+        };
+    }
+}

--- a/app/src/main/java/com/bukhmastov/cdoitmo/data/StorageProxy.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/data/StorageProxy.java
@@ -1,0 +1,11 @@
+package com.bukhmastov.cdoitmo.data;
+
+import android.support.annotation.NonNull;
+
+import com.bukhmastov.cdoitmo.util.Storage;
+
+public interface StorageProxy {
+    @NonNull String get(Storage.StorageType type, String path);
+    boolean put(Storage.StorageType type, String path, String data);
+    boolean delete(Storage.StorageType type, String path);
+}

--- a/app/src/main/java/com/bukhmastov/cdoitmo/data/User.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/data/User.java
@@ -1,0 +1,75 @@
+package com.bukhmastov.cdoitmo.data;
+
+import android.text.TextUtils;
+
+import static com.bukhmastov.cdoitmo.util.Static.contains;
+import static com.bukhmastov.cdoitmo.util.Storage.StorageType.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class User {
+    private final String name;
+    private final String avatar;
+    private final String group;
+    private final List<String> groups;
+
+    public User(String name, String avatar, String group, List<String> groups) {
+        this.name = name;
+        this.avatar = avatar;
+        this.group = group;
+        this.groups = groups != null ? groups : Arrays.asList(group);
+    }
+
+    public String getName() { return name; }
+
+    public String getAvatar() { return avatar; }
+
+    public String getGroup() { return group; }
+
+    public List<String> getGroups() { return groups; }
+
+    public void store(StorageProxy proxy) {
+        proxy.put(PER_USER,"user#name", name);
+        proxy.put(PER_USER, "user#avatar", avatar);
+
+        final String groupOverride = proxy.get(PREFS, "pref_group_force_override").trim();
+        final String[] groups = (groupOverride.isEmpty() ? group : groupOverride).split(",\\s|\\s|,");
+        final String currentGroup = proxy.get(PER_USER, "user#group");
+
+        if (!contains(groups, currentGroup)) {
+            proxy.put(PER_USER,"user#group", groups[0]);
+        }
+        proxy.put(PER_USER,"user#groups", TextUtils.join(", ", groups));
+    }
+
+    public static String getName(StorageProxy proxy) {
+        return proxy.get(PER_USER, "user#name");
+    }
+
+    public static User load(StorageProxy proxy) {
+        final List<String> groups = loadGroups(proxy);
+        final String group = TextUtils.join(", ", groups);
+        final String name = proxy.get(PER_USER, "user#name");
+        final String avatar = proxy.get(PER_USER, "user#avatar");
+
+        return new User(name, avatar, group, groups);
+    }
+
+    private static List<String> loadGroups(StorageProxy proxy) {
+        final String currentGroup = proxy.get(PER_USER, "user#group").trim();
+        final String[] storedGroups = proxy.get(PER_USER, "user#groups").split(",");
+
+        List<String> groups = new ArrayList<>();
+        if (!currentGroup.isEmpty()) {
+            groups.add(currentGroup);
+        }
+        for (String group : storedGroups) {
+            group = group.trim();
+            if (group.equals(currentGroup)) continue;
+            groups.add(group);
+        }
+        return groups;
+    }
+}

--- a/app/src/main/java/com/bukhmastov/cdoitmo/data/UserCredentials.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/data/UserCredentials.java
@@ -1,0 +1,77 @@
+package com.bukhmastov.cdoitmo.data;
+
+import android.support.annotation.Nullable;
+
+import static com.bukhmastov.cdoitmo.util.Storage.StorageType.*;
+
+public class UserCredentials {
+    private final String login;
+    private final String password;
+    private final String role;
+
+    public static final String LOGIN_UNAUTHORIZED = "unauthorized";
+
+    public static final UserCredentials UNAUTHORIZED =
+            new UserCredentials(LOGIN_UNAUTHORIZED, LOGIN_UNAUTHORIZED, "anonymous");
+
+    public UserCredentials(String login, String password, String role) {
+        this.login = login;
+        this.password = password;
+        this.role = role;
+    }
+
+    public String getLogin() { return login; }
+
+    public String getPassword() { return password; }
+
+    public String getRole() { return role; }
+
+    public boolean areInvalid() { return this.login.isEmpty() || this.password.isEmpty(); }
+
+    public static boolean setCurrentLogin(StorageProxy proxy, String login) {
+        return proxy.put(GLOBAL, "users#current_login", login);
+    }
+
+    public static boolean resetCurrentLogin(StorageProxy proxy) {
+        return proxy.delete(GLOBAL, "users#current_login");
+    }
+
+    public static boolean hasCurrentLogin(StorageProxy proxy) {
+        return !getCurrentLogin(proxy).isEmpty();
+    }
+
+    public static void changePasswordByLogin(StorageProxy proxy, String login, String password) {
+        setCurrentLogin(proxy, login);
+        proxy.put(PER_USER, "user#deifmo#password", password);
+        resetCurrentLogin(proxy);
+    }
+
+    public static String getCurrentLogin(StorageProxy proxy) {
+        return proxy.get(GLOBAL, "users#current_login");
+    }
+
+    public static void clearCookies(StorageProxy proxy) {
+        if (!hasCurrentLogin(proxy)) return;
+        proxy.delete(PER_USER, "user#deifmo#cookies");
+    }
+
+    public static void clearPassword(StorageProxy proxy) {
+        if (!hasCurrentLogin(proxy)) return;
+        proxy.delete(PER_USER, "user#deifmo#password");
+    }
+
+    public static @Nullable UserCredentials load(StorageProxy proxy) {
+        String login = proxy.get(PER_USER, "user#deifmo#login");
+        String password = proxy.get(PER_USER, "user#deifmo#password");
+
+        if (login.isEmpty() || password.isEmpty()) return null;
+
+        return new UserCredentials(login, password, proxy.get(PER_USER, "user#role"));
+    }
+
+    public void store(StorageProxy proxy) {
+        proxy.put(PER_USER, "user#deifmo#login", login);
+        proxy.put(PER_USER, "user#deifmo#password", password);
+        proxy.put(PER_USER, "user#role", role);
+    }
+}

--- a/app/src/main/java/com/bukhmastov/cdoitmo/data/Week.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/data/Week.java
@@ -1,0 +1,78 @@
+package com.bukhmastov.cdoitmo.data;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Calendar;
+
+import static com.bukhmastov.cdoitmo.util.Storage.StorageType.*;
+import static com.bukhmastov.cdoitmo.util.Time.getCalendar;
+
+public class Week {
+    private int week;
+    private long timestamp;
+
+    public Week(String week) {
+        this(week, getCalendar().getTimeInMillis());
+    }
+
+    public Week(String week, Long timestamp) {
+        try {
+            this.week = Integer.parseInt(week);
+        }
+        catch (NumberFormatException e) {
+            this.week = -1;
+        }
+        this.timestamp = timestamp;
+    }
+
+    public int getWeek() { return week; }
+
+    public long getTimestamp() { return timestamp; }
+
+    public void store(StorageProxy proxy) {
+        try {
+            proxy.put(GLOBAL, "user#week", new JSONObject().put("week", week).put("timestamp", timestamp).toString());
+        }
+        catch (JSONException e) {/* ignore */}
+    }
+
+    public static int getCurrent(StorageProxy proxy) {
+        return getCurrent(proxy, getCalendar());
+    }
+
+    public static int getCurrent(StorageProxy proxy, Calendar calendar) {
+        int week = -1;
+        long ts = 0;
+        try {
+            final String override = proxy.get(PREFS,"pref_week_force_override");
+            if (!override.isEmpty()) {
+                try {
+                    String[] v = override.split("#");
+                    if (v.length == 2) {
+                        week = Integer.parseInt(v[0]);
+                        ts = Long.parseLong(v[1]);
+                    }
+                } catch (Exception ignore) {/* ignore */}
+            }
+            if (week < 0) {
+                final String stored = proxy.get(GLOBAL, "user#week").trim();
+                if (!stored.isEmpty()) {
+                    try {
+                        JSONObject json = new JSONObject(stored);
+                        week = json.getInt("week");
+                        ts = json.getLong("timestamp");
+                    } catch (Exception e) {
+                        proxy.delete(GLOBAL, "user#week");
+                    }
+                }
+            }
+            if (week >= 0) {
+                final Calendar past = (Calendar) calendar.clone();
+                past.setTimeInMillis(ts);
+                return week + (calendar.get(Calendar.WEEK_OF_YEAR) - past.get(Calendar.WEEK_OF_YEAR));
+            }
+        } catch (Exception ignore) {/* ignore */}
+        return week;
+    }
+}

--- a/app/src/main/java/com/bukhmastov/cdoitmo/firebase/FirebaseCrashlyticsProvider.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/firebase/FirebaseCrashlyticsProvider.java
@@ -3,6 +3,7 @@ package com.bukhmastov.cdoitmo.firebase;
 import android.content.Context;
 import android.support.annotation.StringDef;
 
+import com.bukhmastov.cdoitmo.BuildConfig;
 import com.bukhmastov.cdoitmo.R;
 import com.bukhmastov.cdoitmo.activity.ConnectedActivity;
 import com.bukhmastov.cdoitmo.util.BottomBar;
@@ -20,7 +21,7 @@ import io.fabric.sdk.android.Fabric;
 public class FirebaseCrashlyticsProvider {
 
     private static final String TAG = "FirebaseCrashlyticsProvider";
-    private static boolean enabled = true;
+    private static boolean enabled = !BuildConfig.DEBUG;
 
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({VERBOSE, DEBUG, INFO, WARN, ERROR})
@@ -100,9 +101,9 @@ public class FirebaseCrashlyticsProvider {
     }
 
     public static void exception(final Throwable throwable) {
+        if (!enabled) return;
         Thread.run(Thread.BACKGROUND, () -> {
             try {
-                if (!enabled) return;
                 Crashlytics.logException(throwable);
             } catch (Exception e) {
                 e.printStackTrace();
@@ -111,9 +112,9 @@ public class FirebaseCrashlyticsProvider {
     }
 
     public static void log(final @LEVEL String level, final String TAG, final String log) {
+        if (!enabled) return;
         Thread.run(Thread.BACKGROUND, () -> {
             try {
-                if (!enabled) return;
                 Crashlytics.log(level2priority(level), TAG, log);
             } catch (Exception e) {
                 e.printStackTrace();

--- a/app/src/main/java/com/bukhmastov/cdoitmo/network/DeIfmoClient.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/network/DeIfmoClient.java
@@ -1,9 +1,9 @@
 package com.bukhmastov.cdoitmo.network;
 
 import android.content.Context;
-import android.text.TextUtils;
 
 import com.bukhmastov.cdoitmo.App;
+import com.bukhmastov.cdoitmo.data.StorageProxy;
 import com.bukhmastov.cdoitmo.firebase.FirebaseAnalyticsProvider;
 import com.bukhmastov.cdoitmo.network.interfaces.RawHandler;
 import com.bukhmastov.cdoitmo.network.interfaces.ResponseHandler;
@@ -61,45 +61,13 @@ public class DeIfmoClient extends DeIfmo {
                         @Override
                         public void onSuccess(final int statusCode, final Headers headers, final String response) {
                             Log.v(TAG, "check | success | going to parse user data");
-                            Thread.run(Thread.BACKGROUND, () -> new UserDataParse(response, result -> {
-                                if (result != null) {
+                            Thread.run(Thread.BACKGROUND, () -> new UserDataParse(response, profile -> {
+                                if (profile != null) {
                                     Log.v(TAG, "check | success | parsed");
-                                    String name = com.bukhmastov.cdoitmo.util.TextUtils.getStringSafely(result, "name", "");
-                                    String avatar = com.bukhmastov.cdoitmo.util.TextUtils.getStringSafely(result, "avatar", "");
-                                    String group = com.bukhmastov.cdoitmo.util.TextUtils.getStringSafely(result, "group", "");
-                                    String pref_group_force_override = Storage.pref.get(context, "pref_group_force_override", "");
-                                    if (pref_group_force_override == null) {
-                                        pref_group_force_override = "";
-                                    } else {
-                                        pref_group_force_override = pref_group_force_override.trim();
-                                    }
-                                    String[] groups = (pref_group_force_override.isEmpty() ? group : pref_group_force_override).split(",\\s|\\s|,");
-                                    String g = Storage.file.perm.get(context, "user#group");
-                                    boolean gFound = false;
-                                    for (String g1 : groups) {
-                                        if (g1.equals(g)) {
-                                            gFound = true;
-                                            break;
-                                        }
-                                    }
-                                    if (!gFound) {
-                                        g = groups.length > 0 ? groups[0] : "";
-                                    }
-                                    Storage.file.perm.put(context, "user#name", name);
-                                    Storage.file.perm.put(context, "user#group", g);
-                                    Storage.file.perm.put(context, "user#groups", TextUtils.join(", ", groups));
-                                    Storage.file.perm.put(context, "user#avatar", avatar);
-                                    try {
-                                        Storage.file.general.perm.put(context, "user#week", new JSONObject()
-                                                .put("week", Integer.parseInt(result.getString("week")))
-                                                .put("timestamp", Time.getCalendar().getTimeInMillis())
-                                                .toString()
-                                        );
-                                    } catch (Exception e) {
-                                        Log.exception(e);
-                                        Storage.file.general.perm.delete(context, "user#week");
-                                    }
-                                    FirebaseAnalyticsProvider.setUserProperties(context, group);
+                                    StorageProxy storage = new Storage.Proxy(context);
+                                    profile.user.store(storage);
+                                    profile.week.store(storage);
+                                    FirebaseAnalyticsProvider.setUserProperties(context, profile.user.getGroup());
                                     responseHandler.onSuccess(200, headers, "");
                                 } else {
                                     Log.v(TAG, "check | success | not parsed");

--- a/app/src/main/java/com/bukhmastov/cdoitmo/parse/JSONParse.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/parse/JSONParse.java
@@ -1,0 +1,9 @@
+package com.bukhmastov.cdoitmo.parse;
+
+import org.json.JSONObject;
+
+public abstract class JSONParse extends Parse<JSONObject> {
+    public JSONParse(String data, Response<JSONObject> delegate) {
+        super(data, delegate);
+    }
+}

--- a/app/src/main/java/com/bukhmastov/cdoitmo/parse/Parse.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/parse/Parse.java
@@ -8,16 +8,16 @@ import org.htmlcleaner.HtmlCleaner;
 import org.htmlcleaner.TagNode;
 import org.json.JSONObject;
 
-public abstract class Parse implements Runnable {
+public abstract class Parse<T> implements Runnable {
 
-    private final Response delegate;
+    private final Response<T> delegate;
     private final String data;
 
-    public interface Response {
-        void finish(JSONObject json);
+    public interface Response<T> {
+        void finish(T json);
     }
 
-    public Parse(String data, Response delegate) {
+    public Parse(String data, Response<T> delegate) {
         this.data = data;
         this.delegate = delegate;
     }
@@ -30,9 +30,9 @@ public abstract class Parse implements Runnable {
             if (root == null) {
                 throw new SilentException();
             }
-            JSONObject json = parse(root);
+            T data = parse(root);
             FirebasePerformanceProvider.putAttribute(trace, "state", "done");
-            delegate.finish(json);
+            delegate.finish(data);
         } catch (SilentException silent) {
             FirebasePerformanceProvider.putAttribute(trace, "state", "failed");
             delegate.finish(null);
@@ -46,7 +46,7 @@ public abstract class Parse implements Runnable {
         }
     }
 
-    abstract protected JSONObject parse(TagNode root) throws Throwable;
+    abstract protected T parse(TagNode root) throws Throwable;
 
     abstract protected @FirebasePerformanceProvider.TRACE String getTraceName();
 }

--- a/app/src/main/java/com/bukhmastov/cdoitmo/parse/UserDataParse.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/parse/UserDataParse.java
@@ -1,37 +1,46 @@
 package com.bukhmastov.cdoitmo.parse;
 
+import com.bukhmastov.cdoitmo.data.User;
+import com.bukhmastov.cdoitmo.data.Week;
 import com.bukhmastov.cdoitmo.firebase.FirebasePerformanceProvider;
 
 import org.htmlcleaner.TagNode;
-import org.json.JSONObject;
 
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class UserDataParse extends Parse {
+public class UserDataParse extends Parse<UserDataParse.ProfileData> {
+    public class ProfileData {
+        public final User user;
+        public final Week week;
 
-    public UserDataParse(String data, Response delegate) {
+        ProfileData(User user, Week week) {
+            this.user = user;
+            this.week = week;
+        }
+    }
+
+    public UserDataParse(String data, Response<ProfileData> delegate) {
         super(data, delegate);
     }
 
     @Override
-    protected JSONObject parse(TagNode root) throws Throwable {
-        JSONObject response = new JSONObject();
+    protected ProfileData parse(TagNode root) {
         // находим имя пользователя
         TagNode fio = root.findElementByAttValue("id", "fio", true, false);
-        response.put("name", fio == null ? "" : fio.getText().toString().trim());
+        String name = fio == null ? "" : fio.getText().toString().trim();
         // находим адрес аватарки
-        response.put("avatar", "");
+        String avatar = "";
         TagNode alink_Avatar = root.findElementByAttValue("class", "alink_Avatar", true, false);
         if (alink_Avatar != null && alink_Avatar.hasChildren()) {
             TagNode img = alink_Avatar.findElementByName("img", false);
             if (img != null) {
-                response.put("avatar", "servlet/" + img.getAttributeByName("src").trim().replace("&amp;", "&"));
+                avatar = "servlet/" + img.getAttributeByName("src").trim().replace("&amp;", "&");
             }
         }
         // находим группу пользователя
-        response.put("group", "");
+        String group = "";
         TagNode editForm = root.findElementByAttValue("name", "editForm", true, false);
         if (editForm != null) {
             TagNode div = editForm.findElementByAttValue("class", "d_text", false, false);
@@ -43,7 +52,7 @@ public class UserDataParse extends Parse {
                         for (TagNode row : rows) {
                             List<? extends TagNode> columns = row.getAllElementsList(false);
                             if (columns != null && "группа".equals(columns.get(0).getText().toString().toLowerCase().trim())) {
-                                response.put("group", columns.get(1).getText().toString().trim());
+                                group = columns.get(1).getText().toString().trim();
                                 break;
                             }
                         }
@@ -52,15 +61,15 @@ public class UserDataParse extends Parse {
             }
         }
         // находим номер текущей недели
-        response.put("week", "-1");
+        String week = "";
         TagNode divCalendarIcon = root.findElementByAttValue("id", "divCalendarIcon", true, false);
         if (divCalendarIcon != null) {
             Matcher m = Pattern.compile("^.*\\((.*) нед\\).*$").matcher(divCalendarIcon.getText().toString().trim());
             if (m.find()) {
-                response.put("week", m.group(1));
+                week = m.group(1);
             }
         }
-        return response;
+        return new ProfileData(new User(name, avatar, group, null), new Week(week));
     }
 
     @Override

--- a/app/src/main/java/com/bukhmastov/cdoitmo/parse/rating/RatingListParse.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/parse/rating/RatingListParse.java
@@ -2,6 +2,7 @@ package com.bukhmastov.cdoitmo.parse.rating;
 
 import com.bukhmastov.cdoitmo.exception.SilentException;
 import com.bukhmastov.cdoitmo.firebase.FirebasePerformanceProvider;
+import com.bukhmastov.cdoitmo.parse.JSONParse;
 import com.bukhmastov.cdoitmo.parse.Parse;
 
 import org.htmlcleaner.TagNode;
@@ -11,9 +12,9 @@ import org.json.JSONObject;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class RatingListParse extends Parse {
+public class RatingListParse extends JSONParse {
 
-    public RatingListParse(String data, Response delegate) {
+    public RatingListParse(String data, Response<JSONObject> delegate) {
         super(data, delegate);
     }
 

--- a/app/src/main/java/com/bukhmastov/cdoitmo/parse/rating/RatingParse.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/parse/rating/RatingParse.java
@@ -2,6 +2,7 @@ package com.bukhmastov.cdoitmo.parse.rating;
 
 import com.bukhmastov.cdoitmo.exception.SilentException;
 import com.bukhmastov.cdoitmo.firebase.FirebasePerformanceProvider;
+import com.bukhmastov.cdoitmo.parse.JSONParse;
 import com.bukhmastov.cdoitmo.parse.Parse;
 
 import org.htmlcleaner.TagNode;
@@ -10,9 +11,9 @@ import org.json.JSONObject;
 
 import java.util.List;
 
-public class RatingParse extends Parse {
+public class RatingParse extends JSONParse {
 
-    public RatingParse(String data, Response delegate) {
+    public RatingParse(String data, Response<JSONObject> delegate) {
         super(data, delegate);
     }
 

--- a/app/src/main/java/com/bukhmastov/cdoitmo/parse/rating/RatingTopListParse.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/parse/rating/RatingTopListParse.java
@@ -2,6 +2,7 @@ package com.bukhmastov.cdoitmo.parse.rating;
 
 import com.bukhmastov.cdoitmo.exception.SilentException;
 import com.bukhmastov.cdoitmo.firebase.FirebasePerformanceProvider;
+import com.bukhmastov.cdoitmo.parse.JSONParse;
 import com.bukhmastov.cdoitmo.parse.Parse;
 
 import org.htmlcleaner.TagNode;
@@ -11,11 +12,11 @@ import org.json.JSONObject;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class RatingTopListParse extends Parse {
+public class RatingTopListParse extends JSONParse {
 
     private final String username;
 
-    public RatingTopListParse(String data, String username, Response delegate) {
+    public RatingTopListParse(String data, String username, Response<JSONObject> delegate) {
         super(data, delegate);
         this.username = username;
     }

--- a/app/src/main/java/com/bukhmastov/cdoitmo/parse/room101/Room101DatePickParse.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/parse/room101/Room101DatePickParse.java
@@ -1,6 +1,7 @@
 package com.bukhmastov.cdoitmo.parse.room101;
 
 import com.bukhmastov.cdoitmo.firebase.FirebasePerformanceProvider;
+import com.bukhmastov.cdoitmo.parse.JSONParse;
 import com.bukhmastov.cdoitmo.parse.Parse;
 
 import org.htmlcleaner.TagNode;
@@ -10,9 +11,9 @@ import org.json.JSONObject;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class Room101DatePickParse extends Parse {
+public class Room101DatePickParse extends JSONParse {
 
-    public Room101DatePickParse(String data, Response delegate) {
+    public Room101DatePickParse(String data, Response<JSONObject> delegate) {
         super(data, delegate);
     }
 

--- a/app/src/main/java/com/bukhmastov/cdoitmo/parse/room101/Room101TimeEndPickParse.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/parse/room101/Room101TimeEndPickParse.java
@@ -1,15 +1,16 @@
 package com.bukhmastov.cdoitmo.parse.room101;
 
 import com.bukhmastov.cdoitmo.firebase.FirebasePerformanceProvider;
+import com.bukhmastov.cdoitmo.parse.JSONParse;
 import com.bukhmastov.cdoitmo.parse.Parse;
 
 import org.htmlcleaner.TagNode;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-public class Room101TimeEndPickParse extends Parse {
+public class Room101TimeEndPickParse extends JSONParse {
 
-    public Room101TimeEndPickParse(String data, Response delegate) {
+    public Room101TimeEndPickParse(String data, Response<JSONObject> delegate) {
         super(data, delegate);
     }
 

--- a/app/src/main/java/com/bukhmastov/cdoitmo/parse/room101/Room101TimeStartPickParse.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/parse/room101/Room101TimeStartPickParse.java
@@ -1,15 +1,16 @@
 package com.bukhmastov.cdoitmo.parse.room101;
 
 import com.bukhmastov.cdoitmo.firebase.FirebasePerformanceProvider;
+import com.bukhmastov.cdoitmo.parse.JSONParse;
 import com.bukhmastov.cdoitmo.parse.Parse;
 
 import org.htmlcleaner.TagNode;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-public class Room101TimeStartPickParse extends Parse {
+public class Room101TimeStartPickParse extends JSONParse {
 
-    public Room101TimeStartPickParse(String data, Response delegate) {
+    public Room101TimeStartPickParse(String data, Response<JSONObject> delegate) {
         super(data, delegate);
     }
 

--- a/app/src/main/java/com/bukhmastov/cdoitmo/parse/room101/Room101ViewRequestParse.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/parse/room101/Room101ViewRequestParse.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import com.bukhmastov.cdoitmo.exception.SilentException;
 import com.bukhmastov.cdoitmo.firebase.FirebasePerformanceProvider;
+import com.bukhmastov.cdoitmo.parse.JSONParse;
 import com.bukhmastov.cdoitmo.parse.Parse;
 import com.bukhmastov.cdoitmo.util.Time;
 
@@ -14,11 +15,11 @@ import org.json.JSONObject;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class Room101ViewRequestParse extends Parse {
+public class Room101ViewRequestParse extends JSONParse {
 
     private final Context context;
 
-    public Room101ViewRequestParse(Context context, String data, Response delegate) {
+    public Room101ViewRequestParse(Context context, String data, Response<JSONObject> delegate) {
         super(data, delegate);
         this.context = context;
     }

--- a/app/src/main/java/com/bukhmastov/cdoitmo/parse/schedule/ScheduleAttestationsParse.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/parse/schedule/ScheduleAttestationsParse.java
@@ -2,6 +2,7 @@ package com.bukhmastov.cdoitmo.parse.schedule;
 
 import com.bukhmastov.cdoitmo.exception.SilentException;
 import com.bukhmastov.cdoitmo.firebase.FirebasePerformanceProvider;
+import com.bukhmastov.cdoitmo.parse.JSONParse;
 import com.bukhmastov.cdoitmo.parse.Parse;
 import com.bukhmastov.cdoitmo.util.Log;
 
@@ -9,11 +10,11 @@ import org.htmlcleaner.TagNode;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-public class ScheduleAttestationsParse extends Parse {
+public class ScheduleAttestationsParse extends JSONParse {
 
     private final int term;
 
-    public ScheduleAttestationsParse(String data, int term, Response delegate) {
+    public ScheduleAttestationsParse(String data, int term, Response<JSONObject> delegate) {
         super(data, delegate);
         this.term = term;
     }

--- a/app/src/main/java/com/bukhmastov/cdoitmo/parse/schedule/ScheduleExamsGroupParse.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/parse/schedule/ScheduleExamsGroupParse.java
@@ -1,6 +1,7 @@
 package com.bukhmastov.cdoitmo.parse.schedule;
 
 import com.bukhmastov.cdoitmo.firebase.FirebasePerformanceProvider;
+import com.bukhmastov.cdoitmo.parse.JSONParse;
 import com.bukhmastov.cdoitmo.parse.Parse;
 
 import org.htmlcleaner.TagNode;
@@ -10,13 +11,13 @@ import org.json.JSONObject;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class ScheduleExamsGroupParse extends Parse {
+public class ScheduleExamsGroupParse extends JSONParse {
 
     private final String query;
     private final Pattern groupPattern = Pattern.compile("[a-zа-яё]\\d{4}[a-zа-яё]?", Pattern.CASE_INSENSITIVE);
     private final Pattern advicePattern = Pattern.compile("^Консультация (.{1,10}) в (\\d{1,2}:\\d{1,2}) Место:(.*)$", Pattern.CASE_INSENSITIVE);
 
-    public ScheduleExamsGroupParse(String data, String query, Response delegate) {
+    public ScheduleExamsGroupParse(String data, String query, Response<JSONObject> delegate) {
         super(data, delegate);
         this.query = query;
     }

--- a/app/src/main/java/com/bukhmastov/cdoitmo/parse/schedule/ScheduleExamsTeacherParse.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/parse/schedule/ScheduleExamsTeacherParse.java
@@ -1,6 +1,7 @@
 package com.bukhmastov.cdoitmo.parse.schedule;
 
 import com.bukhmastov.cdoitmo.firebase.FirebasePerformanceProvider;
+import com.bukhmastov.cdoitmo.parse.JSONParse;
 import com.bukhmastov.cdoitmo.parse.Parse;
 
 import org.htmlcleaner.TagNode;
@@ -10,14 +11,14 @@ import org.json.JSONObject;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class ScheduleExamsTeacherParse extends Parse {
+public class ScheduleExamsTeacherParse extends JSONParse {
 
     private final String query;
     private final Pattern teacherPattern = Pattern.compile("^(([a-zа-яА-ЯёЁ]|\\s)*).*$", Pattern.CASE_INSENSITIVE);
     private final Pattern teacherReplacePattern = Pattern.compile("Ассистент|Доцент|Профессор|Ст\\.|препод\\.|Зав\\.|кафедрой|Преподаватель|Расписание\\sэкзаменов|Расписание\\sсессии", Pattern.CASE_INSENSITIVE);
     private final Pattern advicePattern = Pattern.compile("^Консультация (.{1,10}) в (\\d{1,2}:\\d{1,2}) Место:(.*)$", Pattern.CASE_INSENSITIVE);
 
-    public ScheduleExamsTeacherParse(String data, String query, Response delegate) {
+    public ScheduleExamsTeacherParse(String data, String query, Response<JSONObject> delegate) {
         super(data, delegate);
         this.query = query;
     }

--- a/app/src/main/java/com/bukhmastov/cdoitmo/util/Account.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/util/Account.java
@@ -8,6 +8,10 @@ import android.support.v7.app.AlertDialog;
 
 import com.bukhmastov.cdoitmo.App;
 import com.bukhmastov.cdoitmo.R;
+import com.bukhmastov.cdoitmo.data.AccountList;
+import com.bukhmastov.cdoitmo.data.StorageProxy;
+import com.bukhmastov.cdoitmo.data.User;
+import com.bukhmastov.cdoitmo.data.UserCredentials;
 import com.bukhmastov.cdoitmo.firebase.FirebaseAnalyticsProvider;
 import com.bukhmastov.cdoitmo.firebase.FirebasePerformanceProvider;
 import com.bukhmastov.cdoitmo.network.DeIfmoClient;
@@ -17,13 +21,10 @@ import com.bukhmastov.cdoitmo.object.ProtocolTracker;
 import com.bukhmastov.cdoitmo.interfaces.Callable;
 import com.bukhmastov.cdoitmo.interfaces.CallableString;
 
-import org.json.JSONArray;
-
 public class Account {
 
     private static final String TAG = "Account";
 
-    public static final String USER_UNAUTHORIZED = "unauthorized";
     public static boolean authorized = false;
 
     public interface LoginHandler {
@@ -41,19 +42,20 @@ public class Account {
         void onNewRequest(final Client.Request request);
     }
 
-    public static void login(@NonNull final Context context, @NonNull final String login, @NonNull final String password, @NonNull final String role, final boolean isNewUser, @NonNull final LoginHandler loginHandler) {
+    public static void login(@NonNull final Context context, @NonNull final UserCredentials creds, final boolean isNewUser, @NonNull final LoginHandler loginHandler) {
         final String trace = FirebasePerformanceProvider.startTrace(FirebasePerformanceProvider.Trace.LOGIN);
+        final StorageProxy storage = new Storage.Proxy(context);
         Thread.run(() -> {
-            final boolean IS_USER_UNAUTHORIZED = USER_UNAUTHORIZED.equals(login);
-            Log.v(TAG, "login | login=", login, " | password.length()=", password.length(), " | role=", role, " | isNewUser=", isNewUser, " | IS_USER_UNAUTHORIZED=", IS_USER_UNAUTHORIZED, " | OFFLINE_MODE=", App.OFFLINE_MODE);
-            if (login.isEmpty() || password.isEmpty()) {
+            final boolean IS_USER_UNAUTHORIZED = creds == UserCredentials.UNAUTHORIZED;
+            Log.v(TAG, "login | login=", creds.getLogin(), " | password.length()=", creds.getPassword().length(), " | role=", creds.getRole(), " | isNewUser=", isNewUser, " | IS_USER_UNAUTHORIZED=", IS_USER_UNAUTHORIZED, " | OFFLINE_MODE=", App.OFFLINE_MODE);
+            if (creds.areInvalid()) {
                 Thread.runOnUI(() -> {
                     loginHandler.onFailure(context.getString(R.string.required_login_password));
                     FirebasePerformanceProvider.putAttributeAndStop(trace, "state", "failed_credentials_required");
                 });
                 return;
             }
-            if ("general".equals(login)) {
+            if ("general".equals(creds.getLogin())) {
                 Log.w(TAG, "login | got \"general\" login that does not supported");
                 Thread.runOnUI(() -> {
                     loginHandler.onFailure(context.getString(R.string.wrong_login_general));
@@ -62,12 +64,9 @@ public class Account {
                 return;
             }
             Account.authorized = false;
-            Storage.file.general.perm.put(context, "users#current_login", login);
-            if (isNewUser || IS_USER_UNAUTHORIZED) {
-                Storage.file.perm.put(context, "user#deifmo#login", login);
-                Storage.file.perm.put(context, "user#deifmo#password", password);
-                Storage.file.perm.put(context, "user#role", role);
-            }
+
+            UserCredentials.setCurrentLogin(storage, creds.getLogin());
+            if (isNewUser || IS_USER_UNAUTHORIZED) creds.store(storage);
             if (IS_USER_UNAUTHORIZED) {
                 Thread.runOnUI(() -> {
                     Account.authorized = true;
@@ -99,7 +98,15 @@ public class Account {
                 public void onSuccess(int statusCode, Client.Headers headers, String response) {
                     Thread.run(() -> {
                         Account.authorized = true;
-                        List.push(context, login);
+
+                        AccountList accounts = new AccountList(storage);
+                        boolean isNewAuthorization = accounts.add(creds.getLogin());
+
+                        Bundle bundle;
+                        bundle = FirebaseAnalyticsProvider.getBundle(FirebaseAnalyticsProvider.Param.LOGIN_COUNT, accounts.length());
+                        bundle = FirebaseAnalyticsProvider.getBundle(FirebaseAnalyticsProvider.Param.LOGIN_NEW, isNewAuthorization ? "new" : "old", bundle);
+                        FirebaseAnalyticsProvider.logEvent(context, FirebaseAnalyticsProvider.Event.LOGIN, bundle);
+
                         if (isNewUser) {
                             FirebaseAnalyticsProvider.logBasicEvent(context, "New user authorized");
                             ProtocolTracker.setup(context, 0);
@@ -203,9 +210,13 @@ public class Account {
     }
     public static void logout(@NonNull final Context context, @Nullable final String login, @NonNull final LogoutHandler logoutHandler) {
         final String trace = FirebasePerformanceProvider.startTrace(FirebasePerformanceProvider.Trace.LOGOUT);
+        final StorageProxy storage = new Storage.Proxy(context);
         Thread.run(() -> {
-            @NonNull final String cLogin = login != null ? login : Storage.file.general.perm.get(context, "users#current_login");
-            final boolean IS_USER_UNAUTHORIZED = USER_UNAUTHORIZED.equals(cLogin);
+            if (login != null) UserCredentials.setCurrentLogin(storage, login);
+            @NonNull final String cLogin = login != null ? login : UserCredentials.getCurrentLogin(storage);
+            final String uName = User.getName(storage);
+
+            final boolean IS_USER_UNAUTHORIZED = UserCredentials.LOGIN_UNAUTHORIZED.equals(cLogin);
             Log.i(TAG, "logout | login=", cLogin, " | IS_USER_UNAUTHORIZED=", IS_USER_UNAUTHORIZED, " | OFFLINE_MODE=", App.OFFLINE_MODE);
             if ("general".equals(login)) {
                 Log.w(TAG, "logout | got \"general\" login that does not supported");
@@ -316,80 +327,5 @@ public class Account {
                 .setPositiveButton(R.string.do_logout, (dialogInterface, i) -> Thread.runOnUI(callback::call))
                 .setNegativeButton(R.string.do_cancel, null)
                 .create().show());
-    }
-
-    public static class List {
-        private static final String TAG = Account.TAG + ".List";
-        public static void push(@NonNull final Context context, @NonNull final String login) {
-            if (USER_UNAUTHORIZED.equals(login)) return;
-            Thread.run(() -> {
-                try {
-                    Log.v(TAG, "push | login=", login);
-                    boolean isNewAuthorization = true;
-                    // save login on top of the list of authorized users
-                    JSONArray list = get(context);
-                    JSONArray accounts = new JSONArray();
-                    accounts.put(login);
-                    for (int i = 0; i < list.length(); i++) {
-                        String entry = list.getString(i);
-                        if (entry.equals(login)) {
-                            isNewAuthorization = false;
-                        } else {
-                            accounts.put(entry);
-                        }
-                    }
-                    Storage.file.general.perm.put(context, "users#list", accounts.toString());
-                    // track statistics
-                    Bundle bundle;
-                    bundle = FirebaseAnalyticsProvider.getBundle(FirebaseAnalyticsProvider.Param.LOGIN_COUNT, accounts.length());
-                    bundle = FirebaseAnalyticsProvider.getBundle(FirebaseAnalyticsProvider.Param.LOGIN_NEW, isNewAuthorization ? "new" : "old", bundle);
-                    FirebaseAnalyticsProvider.logEvent(
-                            context,
-                            FirebaseAnalyticsProvider.Event.LOGIN,
-                            bundle
-                    );
-                } catch (Exception e) {
-                    Log.exception(e);
-                }
-            });
-        }
-        public static void remove(@NonNull final Context context, @NonNull final String login) {
-            if (USER_UNAUTHORIZED.equals(login)) return;
-            Thread.run(() -> {
-                try {
-                    Log.v(TAG, "remove | login=", login);
-                    // remove login from the list of authorized users
-                    JSONArray list = get(context);
-                    for (int i = 0; i < list.length(); i++) {
-                        if (list.getString(i).equals(login)) {
-                            list.remove(i);
-                            break;
-                        }
-                    }
-                    Storage.file.general.perm.put(context, "users#list", list.toString());
-                    // track statistics
-                    FirebaseAnalyticsProvider.logEvent(
-                            context,
-                            FirebaseAnalyticsProvider.Event.LOGOUT,
-                            FirebaseAnalyticsProvider.getBundle(FirebaseAnalyticsProvider.Param.LOGIN_COUNT, list.length())
-                    );
-                } catch (Exception e) {
-                    Log.exception(e);
-                }
-            });
-        }
-        public static JSONArray get(@NonNull Context context) {
-            try {
-                Log.v(TAG, "get");
-                try {
-                    return TextUtils.string2jsonArray(Storage.file.general.perm.get(context, "users#list", ""));
-                } catch (Exception e) {
-                    return new JSONArray();
-                }
-            } catch (Exception e) {
-                Log.exception(e);
-                return new JSONArray();
-            }
-        }
     }
 }

--- a/app/src/main/java/com/bukhmastov/cdoitmo/util/Migration.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/util/Migration.java
@@ -601,7 +601,7 @@ public class Migration {
         // get rid of pref_allow_owner_notifications
         Storage.pref.delete(context, "pref_allow_owner_notifications");
         // move files
-        Account.logoutTemporarily(context, null);
+        Account.clearAuthorization(/* permanently? */ false, context, null);
         try {
             String path = context.getFilesDir() + File.separator + "app_data";
             File file = new File(path);
@@ -797,7 +797,7 @@ public class Migration {
         if (jobScheduler != null) {
             jobScheduler.cancelAll();
         }
-        Account.logoutPermanently(context, null);
+        Account.clearAuthorization(/* permanently? */ true, context, null);
         Storage.pref.clearExceptPref(context);
     }
 

--- a/app/src/main/java/com/bukhmastov/cdoitmo/util/NavigationMenu.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/util/NavigationMenu.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 
 import com.bukhmastov.cdoitmo.App;
 import com.bukhmastov.cdoitmo.R;
+import com.bukhmastov.cdoitmo.data.User;
 import com.bukhmastov.cdoitmo.firebase.FirebaseConfigProvider;
 import com.bukhmastov.cdoitmo.view.Message;
 
@@ -45,32 +46,13 @@ public class NavigationMenu {
 
     public static void displayUserData(final Context context, final NavigationView navigationView) {
         Thread.run(() -> {
-            final String name = Storage.file.perm.get(context, "user#name");
-            final List<String> groups = getGroups(context);
-            final String group = TextUtils.join(", ", groups);
+            final User user = User.load(new Storage.Proxy(context));
             Thread.runOnUI(() -> {
-                displayUserData(navigationView, R.id.user_name, name);
-                displayUserData(navigationView, R.id.user_group, group);
-                displayUserDataExpand(context, navigationView, groups);
+                displayUserData(navigationView, R.id.user_name, user.getName());
+                displayUserData(navigationView, R.id.user_group, user.getGroup());
+                displayUserDataExpand(context, navigationView, user.getGroups());
             });
         });
-    }
-
-    private static List<String> getGroups(final Context context) {
-        final String g = Storage.file.perm.get(context, "user#group").trim();
-        final String[] gs = Storage.file.perm.get(context, "user#groups").split(",");
-        List<String> groups = new ArrayList<>();
-        if (!g.isEmpty()) {
-            groups.add(g);
-        }
-        for (String g1 : gs) {
-            g1 = g1.trim();
-            if (g1.equals(g)) {
-                continue;
-            }
-            groups.add(g1);
-        }
-        return groups;
     }
 
     private static void displayUserData(final NavigationView navigationView, final int id, final String text) {

--- a/app/src/main/java/com/bukhmastov/cdoitmo/util/Static.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/util/Static.java
@@ -43,7 +43,7 @@ public class Static {
             Log.w(TAG, "hardReset | context is null");
             return;
         }
-        Account.logoutPermanently(context, () -> {
+        Account.clearAuthorization(/* permanently? */ true, context, () -> {
             Storage.file.all.reset(context);
             App.firstLaunch = true;
             App.OFFLINE_MODE = false;

--- a/app/src/main/java/com/bukhmastov/cdoitmo/util/Static.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/util/Static.java
@@ -72,4 +72,11 @@ public class Static {
             }
         });
     }
+
+    public static <T> boolean contains(T[] array, T value) {
+        for (T element : array) {
+            if (element == value || value != null && value.equals(element)) return true;
+        }
+        return false;
+    }
 }

--- a/app/src/main/java/com/bukhmastov/cdoitmo/util/Storage.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/util/Storage.java
@@ -3,8 +3,10 @@ package com.bukhmastov.cdoitmo.util;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.support.annotation.StringDef;
 
+import com.bukhmastov.cdoitmo.data.StorageProxy;
 import com.bukhmastov.cdoitmo.firebase.FirebasePerformanceProvider;
 
 import java.io.File;
@@ -36,6 +38,46 @@ public class Storage {
     public @interface TYPE {}
     public static final String USER = "user";
     public static final String GENERAL = "general";
+
+    public enum StorageType {
+        PER_USER,
+        GLOBAL,
+        PREFS
+    }
+
+    public static class Proxy implements StorageProxy {
+        private Context context;
+
+        public Proxy(Context context) { this.context = context; }
+
+        @NonNull
+        @Override
+        public String get(StorageType type, String path) {
+            switch (type) {
+                case PER_USER: return file.perm.get(context, path, "");
+                case GLOBAL: return file.general.perm.get(context, path, "");
+                default: return pref.get(context, path, "");
+            }
+        }
+
+        @Override
+        public boolean put(StorageType type, String path, String data) {
+            switch (type) {
+                case PER_USER: return file.perm.put(context, path, data);
+                case GLOBAL: return file.general.perm.put(context, path, data);
+                default: pref.put(context, path, data); return true;
+            }
+        }
+
+        @Override
+        public boolean delete(StorageType type, String path) {
+            switch (type) {
+                case PER_USER: return file.perm.delete(context, path);
+                case GLOBAL: return file.general.perm.delete(context, path);
+                default: pref.delete(context, path); return true;
+            }
+        }
+    }
 
     public static class file {
         public static class cache {

--- a/app/src/main/java/com/bukhmastov/cdoitmo/util/TextUtils.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/util/TextUtils.java
@@ -162,14 +162,6 @@ public class TextUtils {
         return string.toString();
     }
 
-    public static String getStringSafely(JSONObject json, String key, String def) {
-        try {
-            return json.getString(key);
-        } catch (Exception e) {
-            return def;
-        }
-    }
-
     public static String bytes2readable(Context context, long bytes) {
         int unit = 1024;
         if (bytes < unit) return bytes + " B";

--- a/app/src/main/java/com/bukhmastov/cdoitmo/util/Time.java
+++ b/app/src/main/java/com/bukhmastov/cdoitmo/util/Time.java
@@ -3,6 +3,7 @@ package com.bukhmastov.cdoitmo.util;
 import android.content.Context;
 
 import com.bukhmastov.cdoitmo.R;
+import com.bukhmastov.cdoitmo.data.Week;
 
 import org.json.JSONObject;
 
@@ -20,42 +21,11 @@ public class Time {
     }
 
     public static int getWeek(Context context) {
-        return getWeek(context, getCalendar());
+        return Week.getCurrent(new Storage.Proxy(context));
     }
 
     public static int getWeek(Context context, Calendar calendar) {
-        int week = -1;
-        long ts = 0;
-        try {
-            final String override = Storage.pref.get(context, "pref_week_force_override", "");
-            if (!override.isEmpty()) {
-                try {
-                    String[] v = override.split("#");
-                    if (v.length == 2) {
-                        week = Integer.parseInt(v[0]);
-                        ts = Long.parseLong(v[1]);
-                    }
-                } catch (Exception ignore) {/* ignore */}
-            }
-            if (week < 0) {
-                final String stored = Storage.file.general.perm.get(context, "user#week").trim();
-                if (!stored.isEmpty()) {
-                    try {
-                        JSONObject json = new JSONObject(stored);
-                        week = json.getInt("week");
-                        ts = json.getLong("timestamp");
-                    } catch (Exception e) {
-                        Storage.file.general.perm.delete(context, "user#week");
-                    }
-                }
-            }
-            if (week >= 0) {
-                final Calendar past = (Calendar) calendar.clone();
-                past.setTimeInMillis(ts);
-                return week + (calendar.get(Calendar.WEEK_OF_YEAR) - past.get(Calendar.WEEK_OF_YEAR));
-            }
-        } catch (Exception ignore) {/* ignore */}
-        return week;
+        return Week.getCurrent(new Storage.Proxy(context), calendar);
     }
 
     public static int getWeekDay() {

--- a/app/src/test/java/android/text/TextUtils.java
+++ b/app/src/test/java/android/text/TextUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.text;
+
+import java.util.Iterator;
+
+
+/* Copied from https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/core/java/android/text/TextUtils.java
+ * This class is required to unit test methods that use TextUtils, since the latter is not mocked
+ * and will throw an exception upon any method invocation.
+ */
+public class TextUtils {
+    /**
+     * Returns a string containing the tokens joined by delimiters.
+     * @param tokens an array objects to be joined. Strings will be formed from
+     *     the objects by calling object.toString().
+     */
+    public static String join(CharSequence delimiter, Object[] tokens) {
+        StringBuilder sb = new StringBuilder();
+        boolean firstTime = true;
+        for (Object token: tokens) {
+            if (firstTime) {
+                firstTime = false;
+            } else {
+                sb.append(delimiter);
+            }
+            sb.append(token);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Returns a string containing the tokens joined by delimiters.
+     * @param tokens an array objects to be joined. Strings will be formed from
+     *     the objects by calling object.toString().
+     */
+    public static String join(CharSequence delimiter, Iterable tokens) {
+        StringBuilder sb = new StringBuilder();
+        Iterator<?> it = tokens.iterator();
+        if (it.hasNext()) {
+            sb.append(it.next());
+            while (it.hasNext()) {
+                sb.append(delimiter);
+                sb.append(it.next());
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/app/src/test/java/com.bukhmastov.cdoitmo/MockStorageProxy.java
+++ b/app/src/test/java/com.bukhmastov.cdoitmo/MockStorageProxy.java
@@ -1,0 +1,45 @@
+package com.bukhmastov.cdoitmo;
+
+import android.support.annotation.NonNull;
+
+import com.bukhmastov.cdoitmo.data.StorageProxy;
+import com.bukhmastov.cdoitmo.data.UserCredentials;
+import com.bukhmastov.cdoitmo.util.Storage;
+
+import java.util.HashMap;
+
+public class MockStorageProxy implements StorageProxy {
+    private HashMap<String, String> global = new HashMap<>();
+    private HashMap<String, String> prefs = new HashMap<>();
+    private HashMap<String, HashMap<String, String>> perUser = new HashMap<>();
+
+    @NonNull
+    @Override
+    public String get(Storage.StorageType type, String path) {
+        String data = getHashMap(type).get(path);
+        if (data == null) return "";
+        else return data;
+    }
+
+    @Override
+    public boolean put(Storage.StorageType type, String path, String data) {
+        getHashMap(type).put(path, data);
+        return true;
+    }
+
+    @Override
+    public boolean delete(Storage.StorageType type, String path) {
+        return getHashMap(type).remove(path) != null;
+    }
+
+    private HashMap<String, String> getHashMap(Storage.StorageType type) {
+        switch (type) {
+            case PER_USER:
+                String user = UserCredentials.getCurrentLogin(this);
+                if (!perUser.containsKey(user)) perUser.put(user, new HashMap<>());
+                return perUser.get(user);
+            case GLOBAL: return global;
+            default: return prefs;
+        }
+    }
+}

--- a/app/src/test/java/com.bukhmastov.cdoitmo/TestHelper.java
+++ b/app/src/test/java/com.bukhmastov.cdoitmo/TestHelper.java
@@ -1,0 +1,20 @@
+package com.bukhmastov.cdoitmo;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+public class TestHelper {
+    public static String readResource(String path) {
+        path = "src/test/resources/" + path;
+        try {
+            return Files.newBufferedReader(Paths.get(path)).lines().collect(Collectors.joining("\n"));
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/app/src/test/java/com.bukhmastov.cdoitmo/data/AccountListTest.java
+++ b/app/src/test/java/com.bukhmastov.cdoitmo/data/AccountListTest.java
@@ -1,0 +1,73 @@
+package com.bukhmastov.cdoitmo.data;
+
+import com.bukhmastov.cdoitmo.MockStorageProxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+
+class AccountListTest {
+    @Test
+    void testAddRemove() throws JSONException {
+        MockStorageProxy storage = new MockStorageProxy();
+
+        AccountList accounts = new AccountList(storage);
+        accounts.add("login1");
+        accounts.add("login2");
+        assertEquals(2, accounts.length());
+
+        accounts = new AccountList(storage);
+        assertEquals(2, accounts.length());
+
+        JSONArray logins = accounts.get();
+        assertEquals("login2", logins.getString(0));
+        assertEquals("login1", logins.getString(1));
+
+        accounts.remove("login2");
+        assertEquals(1, accounts.length());
+
+        accounts = new AccountList(storage);
+        assertEquals(1, accounts.length());
+
+        logins = accounts.get();
+        assertEquals("login1", logins.getString(0));
+    }
+
+    @Test
+    void testIterator() {
+        MockStorageProxy storage = new MockStorageProxy();
+
+        AccountList accounts = new AccountList(storage);
+        accounts.add("login1");
+        accounts.add("login2");
+
+        UserCredentials.setCurrentLogin(storage, "login2");
+        new UserCredentials("login2", "pass2", "role2").store(storage);
+        new User("name2", "", "", null).store(storage);
+
+        UserCredentials.setCurrentLogin(storage, "login1");
+        new UserCredentials("login1", "pass1", "role1").store(storage);
+        new User("name1", "", "", null).store(storage);
+
+        Iterator<AccountList.AccountEntry> iter = new AccountList(storage).iterator();
+        assertTrue(iter.hasNext());
+        AccountList.AccountEntry entry = iter.next();
+        assertEquals("name2", entry.name);
+        assertEquals("login2", entry.creds.getLogin());
+        assertEquals("pass2", entry.creds.getPassword());
+        assertEquals("role2", entry.creds.getRole());
+        assertTrue(iter.hasNext());
+        entry = iter.next();
+        assertEquals("name1", entry.name);
+        assertEquals("login1", entry.creds.getLogin());
+        assertEquals("pass1", entry.creds.getPassword());
+        assertEquals("role1", entry.creds.getRole());
+        assertFalse(iter.hasNext());
+    }
+}

--- a/app/src/test/java/com.bukhmastov.cdoitmo/data/UserTest.java
+++ b/app/src/test/java/com.bukhmastov.cdoitmo/data/UserTest.java
@@ -1,0 +1,37 @@
+package com.bukhmastov.cdoitmo.data;
+
+import com.bukhmastov.cdoitmo.MockStorageProxy;
+import com.bukhmastov.cdoitmo.util.Storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+class UserTest {
+    @Test
+    void testStorage() {
+        MockStorageProxy storage = new MockStorageProxy();
+
+        new User("FN LN", "avatarUrl", "G1000,G2000", null).store(storage);
+
+        User stored = User.load(storage);
+        assertEquals("FN LN", stored.getName());
+        assertEquals("avatarUrl", stored.getAvatar());
+        assertEquals("G1000, G2000", stored.getGroup());
+        assertEquals(Arrays.asList("G1000", "G2000"), stored.getGroups());
+    }
+
+    @Test
+    void testGroupOverride() {
+        MockStorageProxy storage = new MockStorageProxy();
+        storage.put(Storage.StorageType.PREFS, "pref_group_force_override", "G3000");
+
+        new User("FN LN", "avatarUrl", "G1000,G2000", null).store(storage);
+
+        User stored = User.load(storage);
+        assertEquals("G3000", stored.getGroup());
+        assertEquals(Arrays.asList("G3000"), stored.getGroups());
+    }
+}

--- a/app/src/test/java/com.bukhmastov.cdoitmo/data/WeekTest.java
+++ b/app/src/test/java/com.bukhmastov.cdoitmo/data/WeekTest.java
@@ -1,0 +1,43 @@
+package com.bukhmastov.cdoitmo.data;
+
+import com.bukhmastov.cdoitmo.MockStorageProxy;
+import com.bukhmastov.cdoitmo.util.Storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Calendar;
+
+class WeekTest {
+    @Test
+    void testStorage() {
+        MockStorageProxy storage = new MockStorageProxy();
+
+        Calendar cal = Calendar.getInstance();
+        cal.set(2017, 9, 6);
+        long fetchedOn = cal.getTimeInMillis();
+        new Week("2", fetchedOn).store(storage);
+
+        cal.set(2017, 9, 21);
+        assertEquals(4, Week.getCurrent(storage, cal));
+    }
+
+    @Test
+    void testWeekOverride() {
+        MockStorageProxy storage = new MockStorageProxy();
+
+        Calendar cal = Calendar.getInstance();
+        cal.set(2017, 9, 6);
+        long overriddenOn = cal.getTimeInMillis();
+        String overridenAs = "1";
+
+        storage.put(Storage.StorageType.PREFS, "pref_week_force_override",
+                overridenAs + "#" + Long.toString(overriddenOn));
+
+        new Week("2", overriddenOn).store(storage);
+
+        cal.set(2017, 9, 21);
+        assertEquals(3, Week.getCurrent(storage, cal));
+    }
+}

--- a/app/src/test/java/com.bukhmastov.cdoitmo/parse/UserDataParseTest.java
+++ b/app/src/test/java/com.bukhmastov.cdoitmo/parse/UserDataParseTest.java
@@ -1,0 +1,20 @@
+package com.bukhmastov.cdoitmo.parse;
+
+import com.bukhmastov.cdoitmo.TestHelper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class UserDataParseTest {
+    @Test
+    void testProfileFetch() {
+        String page = TestHelper.readResource("parse/editPersonProfile.html");
+        new UserDataParse(page, response -> {
+            assertEquals("Фамилия Имя Отчество", response.user.getName());
+            assertEquals("servlet/distributedCDE?Rule=GETATTACH&ATT_ID=AVATAR_ID", response.user.getAvatar());
+            assertEquals("G0000", response.user.getGroup());
+            assertEquals(19, response.week.getWeek());
+        }).run();
+    }
+}

--- a/app/src/test/resources/parse/editPersonProfile.html
+++ b/app/src/test/resources/parse/editPersonProfile.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html dir="ltr" lang="ru" xml:lang="en">
+<head></head>
+<body marginwidth="0" marginheight="0" id="templ_961">
+<table id="d_structure" class="d_structure">
+    <tbody>
+    <tr>
+        <td id="d_s_top" colspan="2" class="d_s_top">
+            <div id="d_s_t_content" class="d_s_t_content">
+                <table id="d_form" class="d_form d_s_t_line">
+                    <tr><td id="fio" class="fio">Фамилия Имя Отчество</td></tr>
+                </table>
+            </div>
+        </td>
+    </tr>
+    <tr id="d_s_middle" class="d_s_middle">
+        <td id="d_s_m_content" class="d_s_m_content">
+            <a><div id="divCalendarIcon" title="Календарь" isshow="0">[ Сб (19 нед), 16 июн 2018 ]</div></a>
+            <form name="editForm">
+                <div class="d_text">
+                    <table class="d_table">
+                        <tr>
+                            <th>Фамилия</th>
+                            <td colspan="3">Фамилия</td>
+                            <td rowspan="3"><a class="alink_Avatar"><img alt="" src="distributedCDE?Rule=GETATTACH&amp;ATT_ID=AVATAR_ID" width="80px" height="80px"></a></td>
+                        </tr>
+                        <tr>
+                            <th>Имя</th>
+                            <td colspan="3">Имя</td>
+                        </tr>
+                        <tr>
+                            <th>Отчество</th>
+                            <td colspan="3">Отчество</td>
+                        </tr>
+                        <!-- ... -->
+                        <tr>
+                            <th>Группа</th>
+                            <td colspan="2">G0000</td>
+                            <td colspan="2"><!-- ... --></td>
+                        </tr>
+                    </table>
+                </div>
+            </form>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
         classpath 'com.google.gms:google-services:4.0.1'
         classpath 'io.fabric.tools:gradle:1.25.1'
         classpath 'com.google.firebase:firebase-plugins:1.1.5'
+        classpath 'de.mannodermaus.gradle.plugins:android-junit5:1.0.32'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Для введения юнит-тестов (а также лучшего разделения ответственности) хочу предложить использование дата-объектов, которые должны полностью инкапсулировать доступ к постоянному хранилищу и предоставлять готовые данные через публичный интерфейс.

Основная проблема свободного доступа к хранилищу -- повторение кода, в том числа некоторых неочевидных паттернов обращения, в плохотестируемых контекстах (методах, тестно связанных с Android API и интерфейсом).

В данном PR я попытался изолировать хранение пользовательской аутентификации (идеальная модель -- ни одна часть кода кроме дата-объектов не касается `users#current_login`, `user#name` и т.д.), а также добавить юнит-тесты.

Как результат, некоторые большие по количеству кода классы (`DeIfmoClient`, `Account` и др.) были урезаны, а функционал из них приобрел тесты. В то же время объем изменений, которые мне пришлость внести, несколько превзошел мои ожидания, поэтому я хотел бы услышать ваше мнение насчет выбранной мною стратегии. Я готов внести необходимые поправки и, возможно, продолжить рефакторинг, еще больше сокращая "раздувшиеся" классы и добавляя тесты.